### PR TITLE
Rename hardware interface

### DIFF
--- a/abb_hardware_interface/abb_hardware_interface.xml
+++ b/abb_hardware_interface/abb_hardware_interface.xml
@@ -1,6 +1,6 @@
 <library path="abb_hardware_interface">
-  <class name="abb_hardware_interface/ABBSystemPositionOnlyHardware"
-         type="abb_hardware_interface::ABBSystemPositionOnlyHardware"
+  <class name="abb_hardware_interface/ABBSystemHardware"
+         type="abb_hardware_interface::ABBSystemHardware"
          base_class_type="hardware_interface::SystemInterface">
     <description>
 		ROS2 Control ABB driver.

--- a/abb_hardware_interface/include/abb_hardware_interface/abb_hardware_interface.hpp
+++ b/abb_hardware_interface/include/abb_hardware_interface/abb_hardware_interface.hpp
@@ -41,10 +41,10 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 
 namespace abb_hardware_interface
 {
-class ABBSystemPositionOnlyHardware : public hardware_interface::SystemInterface
+class ABBSystemHardware : public hardware_interface::SystemInterface
 {
 public:
-  RCLCPP_SHARED_PTR_DEFINITIONS(ABBSystemPositionOnlyHardware)
+  RCLCPP_SHARED_PTR_DEFINITIONS(ABBSystemHardware)
 
   ROS2_CONTROL_DRIVER_PUBLIC
   CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -21,9 +21,9 @@ using namespace std::chrono_literals;
 namespace abb_hardware_interface
 {
 static constexpr size_t NUM_CONNECTION_TRIES = 100;
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("ABBSystemPositionOnlyHardware");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("ABBSystemHardware");
 
-CallbackReturn ABBSystemPositionOnlyHardware::on_init(const hardware_interface::HardwareInfo& info)
+CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo& info)
 {
   if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
   {
@@ -138,7 +138,7 @@ CallbackReturn ABBSystemPositionOnlyHardware::on_init(const hardware_interface::
   return CallbackReturn::SUCCESS;
 }
 
-std::vector<hardware_interface::StateInterface> ABBSystemPositionOnlyHardware::export_state_interfaces()
+std::vector<hardware_interface::StateInterface> ABBSystemHardware::export_state_interfaces()
 {
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (auto& group : motion_data_.groups)
@@ -161,7 +161,7 @@ std::vector<hardware_interface::StateInterface> ABBSystemPositionOnlyHardware::e
   return state_interfaces;
 }
 
-std::vector<hardware_interface::CommandInterface> ABBSystemPositionOnlyHardware::export_command_interfaces()
+std::vector<hardware_interface::CommandInterface> ABBSystemHardware::export_command_interfaces()
 {
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (auto& group : motion_data_.groups)
@@ -185,7 +185,7 @@ std::vector<hardware_interface::CommandInterface> ABBSystemPositionOnlyHardware:
   return command_interfaces;
 }
 
-CallbackReturn ABBSystemPositionOnlyHardware::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
+CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
 {
   size_t counter = 0;
   RCLCPP_INFO(LOGGER, "Connecting to robot...");
@@ -214,13 +214,13 @@ CallbackReturn ABBSystemPositionOnlyHardware::on_activate(const rclcpp_lifecycle
   return CallbackReturn::SUCCESS;
 }
 
-return_type ABBSystemPositionOnlyHardware::read(const rclcpp::Time& time, const rclcpp::Duration& period)
+return_type ABBSystemHardware::read(const rclcpp::Time& time, const rclcpp::Duration& period)
 {
   egm_manager_->read(motion_data_);
   return return_type::OK;
 }
 
-return_type ABBSystemPositionOnlyHardware::write(const rclcpp::Time& time, const rclcpp::Duration& period)
+return_type ABBSystemHardware::write(const rclcpp::Time& time, const rclcpp::Duration& period)
 {
   egm_manager_->write(motion_data_);
   return return_type::OK;
@@ -230,4 +230,4 @@ return_type ABBSystemPositionOnlyHardware::write(const rclcpp::Time& time, const
 
 #include "pluginlib/class_list_macros.hpp"
 
-PLUGINLIB_EXPORT_CLASS(abb_hardware_interface::ABBSystemPositionOnlyHardware, hardware_interface::SystemInterface)
+PLUGINLIB_EXPORT_CLASS(abb_hardware_interface::ABBSystemHardware, hardware_interface::SystemInterface)

--- a/robot_specific_config/abb_irb1200_support/urdf/irb1200.ros2_control.xacro
+++ b/robot_specific_config/abb_irb1200_support/urdf/irb1200.ros2_control.xacro
@@ -12,7 +12,7 @@
         </xacro:if>
         <!-- physical hardware or RobotStudio simulation -->
         <xacro:unless value="${use_fake_hardware}">
-          <plugin>abb_hardware_interface/ABBSystemPositionOnlyHardware</plugin>
+          <plugin>abb_hardware_interface/ABBSystemHardware</plugin>
           <param name="rws_port">${rws_port}</param>
           <param name="rws_ip">${rws_ip}</param>
           <!-- The following parameter is used for non-MultiMove only -->

--- a/robot_specific_config/abb_irb4600_support/urdf/irb4600.ros2_control.xacro
+++ b/robot_specific_config/abb_irb4600_support/urdf/irb4600.ros2_control.xacro
@@ -12,7 +12,7 @@
         </xacro:if>
         <!-- physical hardware or RobotStudio simulation -->
         <xacro:unless value="${use_fake_hardware}">
-          <plugin>abb_hardware_interface/ABBSystemPositionOnlyHardware</plugin>
+          <plugin>abb_hardware_interface/ABBSystemHardware</plugin>
           <param name="rws_port">${rws_port}</param>
           <param name="rws_ip">${rws_ip}</param>
           <!-- The following parameter is used for non-MultiMove only -->


### PR DESCRIPTION
The hardware interface name used to be ABBSystemPositionOnlyHardware

We now have position and velocity interfaces, so the name should also be updated