### PR TITLE
Initialize MotionData using initial values from ros2_control xacro

### DIFF
--- a/robot_specific_config/abb_irb1200_support/urdf/irb1200.ros2_control.xacro
+++ b/robot_specific_config/abb_irb1200_support/urdf/irb1200.ros2_control.xacro
@@ -26,23 +26,33 @@
         <command_interface name="position">
           <param name="min">{-2*pi}</param>
           <param name="max">{2*pi}</param>
+          <param name="initial_value">0.0</param>
         </command_interface>
-        <command_interface name="velocity"/>
+        <command_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position">
           <param name="min">-2.41</param>
           <param name="max">2.41</param>
+          <param name="initial_value">0.0</param>
         </command_interface>
-        <command_interface name="velocity"/>
+        <command_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position">
@@ -59,34 +69,49 @@
         <command_interface name="position">
           <param name="min">-2.66</param>
           <param name="max">2.66</param>
+          <param name="initial_value">0.0</param>
         </command_interface>
-        <command_interface name="velocity"/>
+        <command_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position">
           <param name="min">{-2*pi}</param>
           <param name="max">{2*pi}</param>
+          <param name="initial_value">0.0</param>
         </command_interface>
-        <command_interface name="velocity"/>
+        <command_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position">
           <param name="min">-2.23</param>
           <param name="max">2.23</param>
+          <param name="initial_value">0.0</param>
         </command_interface>
-        <command_interface name="velocity"/>
+        <command_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
     </ros2_control>
   </xacro:macro>


### PR DESCRIPTION
This PR fixes https://github.com/PickNikRobotics/abb_ros2/issues/44
It relies on changes from https://github.com/ros-industrial/abb_egm_rws_managers/pull/9

In the implementation, the initial value of relevant state and command interfaces are retrieved from the `HardwareInfo`. If these initial_values are not provided in the ros2_control xacro, the values are assumed to be 0.0 which is the same as the current behavior. 