### PR TITLE
Properly configure moveit controllers

### DIFF
--- a/abb_bringup/test/test_command_topics.cpp
+++ b/abb_bringup/test/test_command_topics.cpp
@@ -27,7 +27,7 @@ TEST_F(TaskPlanningFixture, ControllerTopicsTest)
   // Define a map of the topics to check and their types
   std::map<std::string, std::string> expected_topic_names_and_types = {
     { "/joint_trajectory_controller/joint_trajectory", "trajectory_msgs/msg/JointTrajectory" },
-    { "/joint_trajectory_controller/state", "control_msgs/msg/JointTrajectoryControllerState" }
+    { "/joint_trajectory_controller/controller_state", "control_msgs/msg/JointTrajectoryControllerState" }
   };
   for (const auto& [topic_name, topic_type] : expected_topic_names_and_types)
   {

--- a/robot_specific_config/abb_irb1200_5_90_moveit_config/config/moveit_controllers.yaml
+++ b/robot_specific_config/abb_irb1200_5_90_moveit_config/config/moveit_controllers.yaml
@@ -2,20 +2,22 @@ trajectory_execution:
   allowed_execution_duration_scaling: 1.2
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
+  trajectory_duration_monitoring: true
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 
-controller_names:
-  - joint_trajectory_controller
+moveit_simple_controller_manager:
+  controller_names:
+    - joint_trajectory_controller
 
-joint_trajectory_controller:
-  action_ns: follow_joint_trajectory
-  type: FollowJointTrajectory
-  default: true
-  joints:
-    - joint_1
-    - joint_2
-    - joint_3
-    - joint_4
-    - joint_5
-    - joint_6
+  joint_trajectory_controller:
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - joint_1
+      - joint_2
+      - joint_3
+      - joint_4
+      - joint_5
+      - joint_6


### PR DESCRIPTION
Fix #58 

The `moveit_controllers.yaml` is not properly setup and this was uncovered when we switched to `MoveitConfigBulder`.

The changes now align with the controller file for [other robots](https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/config/moveit_controllers.yaml).