### PR TITLE
Avoid moving to zero position on hardware activate

### DIFF
--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -277,6 +277,17 @@ CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* 
   }
 
   egm_manager_->read(motion_data_);
+  for (auto& group : motion_data_.groups)
+  {
+    for (auto& unit : group.units)
+    {
+      for (auto& joint : unit.joints)
+      {
+        joint.command.position = joint.state.position;
+        joint.command.velocity = 0.0;
+      }
+    }
+  }
 
   RCLCPP_INFO(LOGGER, "ros2_control hardware interface was successfully started!");
 


### PR DESCRIPTION
Hello, this PR addresses the issue of robot moving to zero position on hardware interface activation, as described in https://github.com/PickNikRobotics/abb_ros2/issues/44.

To resolve it, this PR assigns the current state read from EGM to the joint commands in the `on_activate` callback (see diff).

I am aware that a PR addressing this is already open (https://github.com/PickNikRobotics/abb_ros2/pull/45), but the proposed solution:
- Does not require changes in the [abb_egm_rws_managers](https://github.com/ros-industrial/abb_egm_rws_managers) repository.
- Does not require additional configuration in the description files (xacro).
- Is robust to external motion commands that bypass EGM (deactivating ROS2 controller, moving robot with pendant, activating ROS2 controller again).

This was tested in RobotStudio, using the [IRB1200_5_90.rspag](https://github.com/PickNikRobotics/abb_ros2/blob/rolling/robot_studio_resources/IRB1200_5_90.rspag) project and RobotWare 6.16.