### PR TITLE
Remove hardcoded joint prefix

### DIFF
--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -98,7 +98,7 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
 
     // Get robot controller description from RWS
     abb::robot::RWSManager rws_manager(rws_ip, rws_port, "Default User", "robotics");
-    robot_controller_description_ = abb::robot::utilities::establishRWSConnection(rws_manager, "IRB1200", true);
+    robot_controller_description_ = abb::robot::utilities::establishRWSConnection(rws_manager, "", true);
   }
   else
   {
@@ -216,14 +216,10 @@ std::vector<hardware_interface::StateInterface> ABBSystemHardware::export_state_
     {
       for (auto& joint : unit.joints)
       {
-        // TODO(seng): Consider changing joint names in robot description to match what comes
-        // from the ABB robot description to avoid needing to strip the prefix here
-        const auto pos = joint.name.find("joint");
-        const auto joint_name = joint.name.substr(pos);
         state_interfaces.emplace_back(
-            hardware_interface::StateInterface(joint_name, hardware_interface::HW_IF_POSITION, &joint.state.position));
+            hardware_interface::StateInterface(joint.name, hardware_interface::HW_IF_POSITION, &joint.state.position));
         state_interfaces.emplace_back(
-            hardware_interface::StateInterface(joint_name, hardware_interface::HW_IF_VELOCITY, &joint.state.velocity));
+            hardware_interface::StateInterface(joint.name, hardware_interface::HW_IF_VELOCITY, &joint.state.velocity));
       }
     }
   }
@@ -239,14 +235,10 @@ std::vector<hardware_interface::CommandInterface> ABBSystemHardware::export_comm
     {
       for (auto& joint : unit.joints)
       {
-        // TODO(seng): Consider changing joint names in robot description to match what comes
-        // from the ABB robot description to avoid needing to strip the prefix here
-        const auto pos = joint.name.find("joint");
-        const auto joint_name = joint.name.substr(pos);
         command_interfaces.emplace_back(hardware_interface::CommandInterface(
-            joint_name, hardware_interface::HW_IF_POSITION, &joint.command.position));
+            joint.name, hardware_interface::HW_IF_POSITION, &joint.command.position));
         command_interfaces.emplace_back(hardware_interface::CommandInterface(
-            joint_name, hardware_interface::HW_IF_VELOCITY, &joint.command.velocity));
+            joint.name, hardware_interface::HW_IF_VELOCITY, &joint.command.velocity));
       }
     }
   }


### PR DESCRIPTION
Hello, this PR removes the hardcoded `IRB1200` prefix assigned to standardized joint names obtained through RWS.

## Bugfix
When multiple mechanical unit groups are defined in RobotStudio, their names are used to construct a prefix when deriving standardized joint names in [abb_egm_rws_managers/SystemDataParser](https://github.com/ros-industrial/abb_egm_rws_managers/blob/master/src/system_data_parser.cpp#L637).
When stripping the hardcoded `IRB1200`, the hardware interface stripped also the mechanical unit group prefix, likely causing https://github.com/PickNikRobotics/abb_ros2/issues/77. 

This was tested in RobotStudio, using the [IRB1200_5_90.rspag](https://github.com/PickNikRobotics/abb_ros2/blob/rolling/robot_studio_resources/IRB1200_5_90.rspag) project and RobotWare 6.16.

## Joint names
When initializing the hardware interface, standardized EGM joint names are matched with URDF joint names.
With the RWS manager, the standardized joint names are constructed like [this](https://github.com/ros-industrial/abb_egm_rws_managers/blob/master/src/system_data_parser.cpp#L620):
`<robot_controller_id>_` + `<mech_unit_group>_` + `joint_` + `<index>`

The `mech_unit_group` is obtained from the controller and is applied if there is more than one.

The `robot_controller_id` can be specified in the [establishRWSConnection](https://github.com/PickNikRobotics/abb_ros2/blob/rolling/abb_hardware_interface/src/utilities.cpp#L81) method, which passes it to the [RWS manager](https://github.com/ros-industrial/abb_egm_rws_managers/blob/master/src/rws_manager.cpp#L77) / [SystemDataParser](https://github.com/ros-industrial/abb_egm_rws_managers/blob/master/src/rws_manager.cpp#L173), which pre-pends it to the standardized joint names (if defined).

### Before
For a single arm, the standardized joint names were:
`IRB1200_joint_1`, `IRB1200_joint_2`, ...
Stripping everything before `joint_` gave us `joint_1`, `joint_2`, ... which was fine as long as URDF joints followed the same convention.

For two arms, the standardized joint names were:
`IRB1200_rob1_joint_1`, `IRB1200_rob1_joint_2`, ...
`IRB1200_rob2_joint_1`, `IRB1200_rob2_joint_2`, ...
In this case, stripping everything before `joint_` also discarded the `rob1_` and `rob2_` prefixes.

### After
After dropping the `IRB1200` prefix, we no longer need to do stripping when matching joint names.
For a single arm, we get `joint_1`, `joint_2`, .. directly from the RWS manager.

For two arms, we get standardized joint names:
`rob1_joint_1`, `rob1_joint_2`, ...
`rob2_joint_1`, `rob2_joint_2`, ...
Which is also fine, as long as the URDF follows the same convention.

## Remaining issue
With this solution and RWS (RobotWare < 7.0 and `configure_via_rws` flag is set), URDF joint names must match the names generated by the RWS manager. For example, it is not possible to define a custom prefix for single-arm joint names.

