### PR TITLE
Lowest version of clang-format is 14 on ubuntu 24.04.

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: Install clang-format-12
-      run: sudo apt-get install clang-format-12
+    - name: Install clang-format-14
+      run: sudo apt-get install clang-format-14
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -17,4 +17,4 @@ jobs:
     - uses: actions/setup-python@v2
     - name: Install clang-format-14
       run: sudo apt-get install clang-format-14
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
See https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=clang-format&searchon=names