### PR TITLE
Fix robot connection check

### DIFF
--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -258,7 +258,7 @@ CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* 
 {
   size_t counter = 0;
   RCLCPP_INFO(LOGGER, "Connecting to robot...");
-  while (rclcpp::ok() && ++counter < NUM_CONNECTION_TRIES)
+  while (rclcpp::ok() && counter++ < NUM_CONNECTION_TRIES)
   {
     // Wait for a message on any of the configured EGM channels.
     if (egm_manager_->waitForMessage(500))


### PR DESCRIPTION
Hello, this PR fixes the robot connection check in ABB hardware interface (as mentioned in https://github.com/PickNikRobotics/abb_ros2/pull/78#issuecomment-2800817459).

## Bug
Currently, the loop `counter` is incremented before comparing it to `NUM_CONNECTION_RETRIES`. The `counter` can therefore never be equal to `NUM_CONNECTION_RETRIES` within the loop, so the following check can never be true:
```cpp
    if (counter == NUM_CONNECTION_TRIES)
    {
      RCLCPP_ERROR(LOGGER, "Failed to connect to robot");
      return CallbackReturn::ERROR;
    }
```
This means that even if robot connection fails, the hardware interface falsely reports a successful activation.

## Bugfix
By switching to post-increment, we ensure that `counter == NUM_CONNECTION_RETRIES` in the final loop and the activation error is raised if robot connection fails.

## Test
We can test this by running the following command without the robot or simulator connected, and waiting for the timeout:
`ros2 launch abb_bringup abb_control.launch.py description_package:=abb_irb1200_support description_file:=irb1200_5_90.xacro launch_rviz:=false use_fake_hardware:=false configure_via_rws:=false`

Without this bugfix, the driver reports successful activation of robot hardware and controllers after connection timeout.
With this bugfix, the driver raises a hardware activation error.

