### PR TITLE
Add missing exec_depends

### DIFF
--- a/abb_bringup/package.xml
+++ b/abb_bringup/package.xml
@@ -29,6 +29,10 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>moveit_planners</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/robot_specific_config/abb_irb1200_support/package.xml
+++ b/robot_specific_config/abb_irb1200_support/package.xml
@@ -48,6 +48,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+
   <export>
       <build_type>ament_cmake</build_type>
     <!-- <architecture_independent/> -->

--- a/robot_specific_config/abb_irb4600_support/package.xml
+++ b/robot_specific_config/abb_irb4600_support/package.xml
@@ -36,6 +36,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/abb_ros2/issues/83

Fixing:
![image](https://github.com/user-attachments/assets/76134ad4-538e-43de-bde7-8ade4b1cfa59)

move_it_simple_controller_manager:
![image](https://github.com/user-attachments/assets/c77316e8-e499-4dd6-a594-596bd7ea07d8)

