### PR TITLE
Change to have acceleration limit and update OMPL configuration format

### DIFF
--- a/robot_specific_config/abb_irb1200_5_90_moveit_config/config/joint_limits.yaml
+++ b/robot_specific_config/abb_irb1200_5_90_moveit_config/config/joint_limits.yaml
@@ -5,30 +5,30 @@ joint_limits:
   joint_1:
     has_velocity_limits: true
     max_velocity: 5.027
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0 # should be updated to actual values (all max_accelerations).
   joint_2:
     has_velocity_limits: true
     max_velocity: 4.189
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
   joint_3:
     has_velocity_limits: true
     max_velocity: 5.236
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
   joint_4:
     has_velocity_limits: true
     max_velocity: 6.981
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
   joint_5:
     has_velocity_limits: true
     max_velocity: 7.069
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
   joint_6:
     has_velocity_limits: true
     max_velocity: 10.472
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 5.0

--- a/robot_specific_config/abb_irb1200_5_90_moveit_config/config/ompl_planning.yaml
+++ b/robot_specific_config/abb_irb1200_5_90_moveit_config/config/ompl_planning.yaml
@@ -1,12 +1,14 @@
-planning_plugin: ompl_interface/OMPLPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/ResolveConstraintFrames
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
-start_state_max_bounds_error: 0.1
+planning_plugins:
+  - ompl_interface/OMPLPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL


### PR DESCRIPTION

![Skærmbillede 2025-05-31 125007](https://github.com/user-attachments/assets/3c426f09-2c9e-4a45-bc2a-1097fea81f30)

Setting joint acceleration limits based on:
https://docs.universal-robots.com/Universal_Robots_ROS2_Documentation/doc/ur_tutorials/my_robot_cell/doc/build_moveit_config.html#manual-adaptions
https://github.com/PickNikRobotics/abb_ros2/issues/73

Setting OMPL based on:
https://moveit.picknik.ai/main/api/html/md_MIGRATION.html
https://github.com/PickNikRobotics/abb_ros2/issues/73

Closes https://github.com/PickNikRobotics/abb_ros2/issues/73 after https://github.com/PickNikRobotics/abb_ros2/pull/87.