### PR TITLE
Fix: Use valid SPDX license identifiers and add a NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+abb_ros2
+Copyright (c) 2022 PickNik Inc.
+
+This product includes software developed by third parties, listed below with
+the license under which each is distributed. See LICENSE for the Apache License
+2.0 text, and the headers of individual source files for the notice that
+applies to them.
+
+--------------------------------------------------------------------------------
+ABB Schweiz AG
+Copyright (c) 2020, ABB Schweiz AG
+Licensed under BSD-3-Clause.
+Covers the ABB robot interface utilities in abb_hardware_interface (for example
+abb_hardware_interface/src/utilities.cpp), which is why that package declares
+both Apache-2.0 and BSD-3-Clause in its package.xml.
+
+--------------------------------------------------------------------------------
+ROS 2 Control Development Team
+Copyright 2020 ROS2-Control Development Team
+Licensed under the Apache License, Version 2.0.
+Covers the hardware interface implementation in abb_hardware_interface, modified
+by PickNik Inc. in 2022.
+
+--------------------------------------------------------------------------------
+Open Source Robotics Foundation, Inc.
+Copyright 2017 Open Source Robotics Foundation, Inc.
+Licensed under the Apache License, Version 2.0.
+
+--------------------------------------------------------------------------------
+ROS-Industrial
+Licensed under BSD-3-Clause.
+Covers robot_specific_config/abb_irb1200_5_90_moveit_config, an automatically
+generated MoveIt configuration authored by Andrew Short and maintained by Levi
+Armstrong (Southwest Research Institute). This package is BSD-3-Clause rather
+than Apache-2.0, and its package.xml declares that deliberately.

--- a/abb_bringup/package.xml
+++ b/abb_bringup/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="zelenak@picknik.ai">Andy Zelenak</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
 
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/abb_hardware_interface/package.xml
+++ b/abb_hardware_interface/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="zelenak@picknik.ai">Andy Zelenak</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
 
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
   <license>BSD-3-Clause</license>
 
   <author email="dmitri.ignakov@taigarobotics.com">Dmitri Ignakov</author>

--- a/abb_resources/package.xml
+++ b/abb_resources/package.xml
@@ -14,7 +14,7 @@
   <author email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</author>
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <url type="website">http://wiki.ros.org/abb_resources</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb/issues</url>

--- a/abb_ros2/package.xml
+++ b/abb_ros2/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="zelenak@picknik.ai">Andy Zelenak</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
 
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <author email="dmitri.ignakov@taigarobotics.com">Dmitri Ignakov</author>
   <author email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</author>

--- a/abb_rws_client/package.xml
+++ b/abb_rws_client/package.xml
@@ -6,7 +6,7 @@
   <description>TODO: Package description</description>
   <maintainer email="gbartyzel@hotmail.com">Grzegorz Bartyzel</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <depend>rclcpp</depend>
   <depend>abb_egm_rws_managers</depend>

--- a/robot_specific_config/abb_irb1200_5_90_moveit_config/package.xml
+++ b/robot_specific_config/abb_irb1200_5_90_moveit_config/package.xml
@@ -17,7 +17,7 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://wiki.ros.org/abb_irb1200_5_90_moveit_config</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>

--- a/robot_specific_config/abb_irb1200_support/package.xml
+++ b/robot_specific_config/abb_irb1200_support/package.xml
@@ -40,7 +40,7 @@
   <author>Geoffrey Chiou (Southwest Research Institute)</author>
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <url type="website">http://wiki.ros.org/abb_irb1200_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>

--- a/robot_specific_config/abb_irb4600_support/package.xml
+++ b/robot_specific_config/abb_irb4600_support/package.xml
@@ -28,7 +28,7 @@
   <author>Rik Tonnaer (SAM|XL)</author>
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <maintainer email="yadunund@gmail.com">Yadunund</maintainer>
-  <license>Apache2</license>
+  <license>Apache-2.0</license>
 
   <url type="website">http://wiki.ros.org/abb_irb4600_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb_experimental/issues</url>


### PR DESCRIPTION
[written by AI]

## Problem

Every `package.xml` in this repo declared a license string that is not a valid SPDX identifier, so no automated tool can resolve what this code is licensed under. Seven packages said `Apache2` (SPDX is `Apache-2.0`) and one said `BSD` (ambiguous between 2-clause and 3-clause).

Separately, the repo is Apache-2.0 but ships code from four distinct copyright holders with no `NOTICE` file recording them. Apache-2.0 section 4(d) is written around exactly that file.

## Changes

**1. Valid SPDX identifiers.** `Apache2` becomes `Apache-2.0` in seven packages, and `BSD` becomes `BSD-3-Clause` in `abb_irb1200_5_90_moveit_config`. **No package's actual license changes**, only the spelling of the identifier.

**2. A `NOTICE` file** recording the four copyright holders whose code ships here, each with the license that applies and which files it covers. Sourced from the source-file headers, not assumed:

| Holder | License | Where |
|---|---|---|
| ABB Schweiz AG (2020) | BSD-3-Clause | `abb_hardware_interface/src/utilities.cpp` and related |
| ROS2-Control Development Team (2020) | Apache-2.0 | `abb_hardware_interface`, modified by PickNik in 2022 |
| Open Source Robotics Foundation (2017) | Apache-2.0 | |
| ROS-Industrial (Andrew Short, Levi Armstrong / SwRI) | BSD-3-Clause | `abb_irb1200_5_90_moveit_config` |

## Two things deliberately left alone

**`abb_irb1200_5_90_moveit_config` stays BSD-3-Clause, not Apache-2.0.** An audit initially flagged it as conflicting with the repo's Apache-2.0 root. On inspection the mismatch is **correct**: it is an automatically generated ROS-Industrial MoveIt config authored by Andrew Short and maintained by Levi Armstrong at SwRI, and ROS-Industrial ships BSD-3-Clause. Forcing it to match the root would have relicensed someone else's code. The `NOTICE` now says so explicitly, so the next audit does not re-flag it.

Likewise `abb_hardware_interface` keeps **both** `Apache-2.0` and `BSD-3-Clause` tags. That dual declaration is right: `abb_hardware_interface.cpp` is Apache-2.0 (ros2_control team, modified by PickNik) and `utilities.cpp` is BSD-3-Clause (ABB Schweiz AG).

**The `LICENSE` file is untouched.** Its appendix still carries the standard `[yyyy] [name of copyright owner]` placeholder, which is how the Apache-2.0 template ships. With four copyright holders, filling that in with a single name would overclaim. The `NOTICE` is the correct place for that information and is what this PR adds.

## Scope

Eight `package.xml` files (one line each) plus a new `NOTICE`. No code, no build changes, no behavior change. `<license>` is manifest metadata that no build step consumes.

## Manual verification

None needed for the metadata. Reviewer sanity check worth doing: confirm the `NOTICE` attributions match what you know of this repo's history, since it is the only file here making factual claims.

Found during a licensing audit of all 109 PickNik-authored public repos. Tracked in PickNikRobotics/moveit_pro#22271.
