### PR TITLE
Fix: Name the copyright owner in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 PickNik Inc. and the abb_ros2 contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
[written by AI]

## Problem

`LICENSE` is the pristine Apache-2.0 template. Its appendix still reads `Copyright [yyyy] [name of copyright owner]`, and no other line in the file names an owner, so the repo-level license identifies no copyright holder at all.

## Fix

Name PickNik Inc. and the contributors, with 2022 as the year the current license was put in place (`Remove Proprietary licensing`, #17).

The wording credits contributors rather than PickNik alone because this is a multi-party codebase and the per-file headers stay authoritative for the parts PickNik did not write: `abb_rws_client` is `Copyright (c) 2020, ABB Schweiz AG`, `abb_hardware_interface` is `Copyright 2020 ROS2-Control Development Team` with PickNik modifications, and `abb_resources` lists Southwest Research Institute. A bare "PickNik Inc." line would read as a claim over those.

One line changed. The license text itself is untouched.
